### PR TITLE
Improved feedback on survey pages

### DIFF
--- a/AdaptiveSurveyBackend/src/main/java/ch/idsia/adaptive/backend/controller/SurveyController.java
+++ b/AdaptiveSurveyBackend/src/main/java/ch/idsia/adaptive/backend/controller/SurveyController.java
@@ -285,14 +285,14 @@ public class SurveyController {
 					.setIsCorrect(qa.getIsCorrect())
 					.setQuestion(qa.getQuestion());
 
-			answer = answers.save(answer);
-			manager.checkAnswer(data, answer);
+			final boolean b = manager.checkAnswer(data, answer);
+			if (b) {
+				answer = answers.save(answer);
+				sessions.setLastAnswerTime(session);
 
-			sessions.setLastAnswerTime(session);
-
-			State s = manager.getState(data).setSession(session);
-
-			statuses.save(s);
+				State s = manager.getState(data).setSession(session);
+				statuses.save(s);
+			}
 
 			return new ResponseEntity<>(HttpStatus.OK);
 		} catch (SessionException e) {

--- a/AdaptiveSurveyBackend/src/main/java/ch/idsia/adaptive/backend/services/SurveyManagerService.java
+++ b/AdaptiveSurveyBackend/src/main/java/ch/idsia/adaptive/backend/services/SurveyManagerService.java
@@ -86,8 +86,8 @@ public class SurveyManagerService {
 		return getSurvey(data).stop();
 	}
 
-	public void checkAnswer(SurveyData data, Answer answer) {
-		getSurvey(data).check(answer);
+	public boolean checkAnswer(SurveyData data, Answer answer) {
+		return getSurvey(data).check(answer);
 	}
 
 	public Question nextQuestion(SurveyData data) throws SurveyException {

--- a/AdaptiveSurveyBackend/src/main/java/ch/idsia/adaptive/backend/services/commons/agents/Agent.java
+++ b/AdaptiveSurveyBackend/src/main/java/ch/idsia/adaptive/backend/services/commons/agents/Agent.java
@@ -21,10 +21,11 @@ public interface Agent {
 	/**
 	 * Checks the answer to the given question.
 	 *
-	 * @param question question to check
-	 * @param answer   answer given
+	 * @param answer answer given
+	 * @return true if the answer was correctly recorded, otherwise (as an example, in case the answer is for the wrong
+	 * question) false.
 	 */
-	void check(Answer answer);
+	boolean check(Answer answer);
 
 	/**
 	 * @return true if stop conditions are met, otherwise false.

--- a/AdaptiveSurveyBackend/src/main/java/ch/idsia/adaptive/backend/services/commons/agents/AgentGeneric.java
+++ b/AdaptiveSurveyBackend/src/main/java/ch/idsia/adaptive/backend/services/commons/agents/AgentGeneric.java
@@ -136,6 +136,7 @@ public abstract class AgentGeneric<F extends GenericFactor> implements Agent {
 		currentQuestion = q;
 
 		logger.debug("next question is skill={} question={}", s.getName(), q.getName());
+		answered = false;
 	}
 
 	@Override
@@ -148,11 +149,15 @@ public abstract class AgentGeneric<F extends GenericFactor> implements Agent {
 	}
 
 	@Override
-	public void check(Answer answer) {
-		final Integer variable = answer.getQuestion().getVariable();
-		final Integer state = answer.getQuestionAnswer().getState();
-		observations.put(variable, state);
-		answered = true;
+	public boolean check(Answer answer) {
+		if (currentQuestion != null && currentQuestion.getVariable().equals(answer.getQuestion().getVariable())) {
+			final Integer variable = answer.getQuestion().getVariable();
+			final Integer state = answer.getQuestionAnswer().getState();
+			observations.put(variable, state);
+			answered = true;
+			return true;
+		}
+		return false;
 	}
 
 	@Override

--- a/AdaptiveSurveyBackend/src/main/resources/static/css/style.css
+++ b/AdaptiveSurveyBackend/src/main/resources/static/css/style.css
@@ -4,11 +4,14 @@ label {
 
 svg {
     background-color: white;
+    border: 1px solid rgba(0, 0, 0, .125);
+    border-radius: .25rem;
 }
 
 .charts {
     display: flex;
     justify-content: space-between;
+    margin: 1em;
 }
 
 .tooltip {
@@ -16,4 +19,55 @@ svg {
     border: 1px solid black;
     padding: 10px;
     opacity: 0;
+}
+
+.code {
+    font-family: monospace;
+    background-color: #cccccc;
+    padding: 2pt;
+}
+
+.answers {
+    display: flex;
+    justify-content: space-evenly;
+    flex-wrap: wrap;
+}
+
+.radio-custom {
+    display: none;
+}
+
+.radio-custom-label {
+    border: 1px solid rgba(0, 0, 0, .125);
+    border-radius: .25rem;
+    background-color: white;
+    padding: 2pt;
+    min-width: 5em;
+    flex-grow: 1;
+    text-align: center;
+}
+
+.radio-custom-label:hover {
+    background-color: dodgerblue;
+}
+
+.radio-custom:checked ~ label {
+    background-color: dodgerblue;
+    color: white;
+}
+
+.submit {
+    text-align: center;
+    margin: 1em;
+}
+
+.submit > input {
+    background-color: white;
+    border: 1px solid rgba(0, 0, 0, .125);
+    border-radius: .25rem;
+    padding: 0.5em 1em;
+}
+
+.submit > input:hover {
+    background-color: dodgerblue;
 }

--- a/AdaptiveSurveyBackend/src/main/resources/static/css/style.css
+++ b/AdaptiveSurveyBackend/src/main/resources/static/css/style.css
@@ -4,5 +4,16 @@ label {
 
 svg {
     background-color: white;
-    width: 460px;
+}
+
+.charts {
+    display: flex;
+    justify-content: space-between;
+}
+
+.tooltip {
+    background-color: white;
+    border: 1px solid black;
+    padding: 10px;
+    opacity: 0;
 }

--- a/AdaptiveSurveyBackend/src/main/resources/static/css/style.css
+++ b/AdaptiveSurveyBackend/src/main/resources/static/css/style.css
@@ -1,3 +1,8 @@
 label {
     min-width: 10em;
 }
+
+svg {
+    background-color: white;
+    width: 460px;
+}

--- a/AdaptiveSurveyBackend/src/main/resources/static/js/charts.js
+++ b/AdaptiveSurveyBackend/src/main/resources/static/js/charts.js
@@ -1,22 +1,31 @@
 const colors = ['#e41a1c', '#377eb8', '#4daf4a', '#984ea3', '#ff7f00', '#ffff33', '#a65628', '#f781bf', '#999999']
 
 const margin = {top: 10, right: 30, bottom: 30, left: 60};
-const width = 460 - margin.left - margin.right;
+const width = 500 - margin.left - margin.right;
 const height = 400 - margin.top - margin.bottom;
 
 // entropy chart
-let svg = d3.select('#chart-entropy')
-    .append("svg")
-    .attr("width", width + margin.left + margin.right)
-    .attr("height", height + margin.top + margin.bottom)
-    .append("g")
-    .attr("transform",
-        "translate(" + margin.left + "," + margin.top + ")");
+const svge = d3.select('#chart-entropy')
+    .append('svg')
+    .attr('width', width + margin.left + margin.right)
+    .attr('height', height + margin.top + margin.bottom)
+    .append('g')
+    .attr('transform', `translate(${margin.left}, ${margin.top})`);
 
+// distribution chart
+const svgd = d3.select('#chart-distribution')
+    .append('svg')
+    .attr('width', width + margin.left + margin.right)
+    .attr('height', height + margin.top + margin.bottom)
+    .append('g')
+    .attr('transform', `translate(${margin.left}, ${margin.top})`);
+
+// following is the entropy lines chart
 d3.json(
     '/survey/states/' + token,
     function (data) {
         let entropies = []
+
         data.forEach(d => {
             d.skills.forEach(s => {
                 entropies.push({'answers': d.totalAnswers, 'skill': s.name, 'value': d.entropyDistribution[s.name]})
@@ -25,56 +34,102 @@ d3.json(
 
         // group the data: I want to draw one line per group
         let sumstat = d3.nest() // nest function allows to group the calculation per level of a factor
-            .key(function (d) {
-                return d.skill;
-            })
+            .key((d) => d.skill)
             .entries(entropies);
 
-        // Add X axis
         let x = d3.scaleLinear()
-            .domain([0, d3.max(data, function (d) {
-                return d.totalAnswers + 1;
-            })])
+            .domain([0, d3.max(data, (d) => d.totalAnswers + 1)])
             .range([0, width]);
-        svg.append("g")
-            .attr("transform", "translate(0," + height + ")")
+        svge.append('g')
+            .attr('transform', `translate(0, ${height})`)
             .call(d3.axisBottom(x));
 
-        // Add Y axis
         let y = d3.scaleLinear()
             .domain([0, 1])
             .range([height, 0]);
-        svg.append("g")
+        svge.append('g')
             .call(d3.axisLeft(y));
 
-        let res = sumstat.map(function (d) {
-            return d.key
-        });
+        let res = sumstat.map((d) => d.key);
         // list of group names
         let color = d3.scaleOrdinal()
             .domain(res)
             .range(colors.slice(0, res.length));
 
-        // Add the line
-        svg.selectAll(".line")
+        svge.selectAll('.line')
             .data(sumstat)
             .enter()
-            .append("path")
-            .attr("fill", "none")
-            .attr("stroke", function (d) {
-                return color(d.key)
-            })
-            .attr("stroke-width", 1.5)
-            .attr("d", function (d) {
+            .append('path')
+            .attr('fill', 'none')
+            .attr('stroke', (d) => color(d.key))
+            .attr('stroke-width', 1.5)
+            .attr('d', (d) => {
                 return d3.line()
-                    .x(function (d) {
-                        return x(d.answers);
-                    })
-                    .y(function (d) {
-                        return y(+d.value);
-                    })
+                    .x((d) => x(d.answers))
+                    .y((d) => y(+d.value))
                     (d.values)
-            })
+            });
     }
 );
 
+// following is the entropy lines chart
+d3.json(
+    '/survey/state/' + token,
+    function (data) {
+        let distributions = []
+        data.skills.forEach(s => {
+            s.states.forEach(st => {
+                distributions.push({
+                    'name': `P(${s.name}=${st.name})`,
+                    'value': data.skillDistribution[s.name][st.state]
+                })
+            });
+        });
+
+        let x = d3.scaleBand()
+            .range([0, width])
+            .domain(distributions.map((d) => d.name))
+            .padding(0.2);
+
+        svgd.append('g')
+            .attr('transform', `translate(0, ${height})`)
+            .call(d3.axisBottom(x));
+
+        let y = d3.scaleLinear()
+            .domain([0, 1])
+            .range([height, 0]);
+        svgd.append('g')
+            .call(d3.axisLeft(y));
+
+        // tooltip
+        let tooltip = d3.select('#chart-distribution').append('div').attr('class', 'tooltip');
+
+        let mouseOver = function (d) {
+            let key = d.name;
+            let value = d.value;
+            tooltip.html(`${key} = ${value}`).style('opacity', 1);
+        }
+        let mouseMove = function (d) {
+            const [x, y] = d3.mouse(this);
+            tooltip
+                .style("left", (x + 500) + "px")
+                .style("top", (y + 100) + "px");
+        }
+        let mouseLeave = function (d) {
+            tooltip.style("opacity", 0);
+        }
+
+        svgd.selectAll('mybar')
+            .data(distributions)
+            .enter()
+            .append('rect')
+            .attr('x', (d) => x(d.name))
+            .attr('y', (d) => y(d.value))
+            .attr('width', x.bandwidth())
+            .attr('height', (d) => height - y(d.value))
+            .attr('fill', '#69b3a2')
+            .on("mouseover", mouseOver)
+            .on("mousemove", mouseMove)
+            .on("mouseleave", mouseLeave);
+    }
+);

--- a/AdaptiveSurveyBackend/src/main/resources/static/js/charts.js
+++ b/AdaptiveSurveyBackend/src/main/resources/static/js/charts.js
@@ -1,0 +1,80 @@
+const colors = ['#e41a1c', '#377eb8', '#4daf4a', '#984ea3', '#ff7f00', '#ffff33', '#a65628', '#f781bf', '#999999']
+
+const margin = {top: 10, right: 30, bottom: 30, left: 60};
+const width = 460 - margin.left - margin.right;
+const height = 400 - margin.top - margin.bottom;
+
+// entropy chart
+let svg = d3.select('#chart-entropy')
+    .append("svg")
+    .attr("width", width + margin.left + margin.right)
+    .attr("height", height + margin.top + margin.bottom)
+    .append("g")
+    .attr("transform",
+        "translate(" + margin.left + "," + margin.top + ")");
+
+d3.json(
+    '/survey/states/' + token,
+    function (data) {
+        let entropies = []
+        data.forEach(d => {
+            d.skills.forEach(s => {
+                entropies.push({'answers': d.totalAnswers, 'skill': s.name, 'value': d.entropyDistribution[s.name]})
+            });
+        });
+
+        // group the data: I want to draw one line per group
+        let sumstat = d3.nest() // nest function allows to group the calculation per level of a factor
+            .key(function (d) {
+                return d.skill;
+            })
+            .entries(entropies);
+
+        // Add X axis
+        let x = d3.scaleLinear()
+            .domain([0, d3.max(data, function (d) {
+                return d.totalAnswers + 1;
+            })])
+            .range([0, width]);
+        svg.append("g")
+            .attr("transform", "translate(0," + height + ")")
+            .call(d3.axisBottom(x));
+
+        // Add Y axis
+        let y = d3.scaleLinear()
+            .domain([0, 1])
+            .range([height, 0]);
+        svg.append("g")
+            .call(d3.axisLeft(y));
+
+        let res = sumstat.map(function (d) {
+            return d.key
+        });
+        // list of group names
+        let color = d3.scaleOrdinal()
+            .domain(res)
+            .range(colors.slice(0, res.length));
+
+        // Add the line
+        svg.selectAll(".line")
+            .data(sumstat)
+            .enter()
+            .append("path")
+            .attr("fill", "none")
+            .attr("stroke", function (d) {
+                return color(d.key)
+            })
+            .attr("stroke-width", 1.5)
+            .attr("d", function (d) {
+                return d3.line()
+                    .x(function (d) {
+                        return x(d.answers);
+                    })
+                    .y(function (d) {
+                        return y(+d.value);
+                    })
+                    (d.values)
+            })
+    }
+);
+

--- a/AdaptiveSurveyBackend/src/main/resources/static/js/charts.js
+++ b/AdaptiveSurveyBackend/src/main/resources/static/js/charts.js
@@ -1,6 +1,6 @@
 const colors = ['#e41a1c', '#377eb8', '#4daf4a', '#984ea3', '#ff7f00', '#ffff33', '#a65628', '#f781bf', '#999999']
 
-const margin = {top: 10, right: 30, bottom: 30, left: 60};
+const margin = {top: 20, right: 30, bottom: 60, left: 60};
 const width = 500 - margin.left - margin.right;
 const height = 400 - margin.top - margin.bottom;
 
@@ -38,7 +38,7 @@ d3.json(
             .entries(entropies);
 
         let x = d3.scaleLinear()
-            .domain([0, d3.max(data, (d) => d.totalAnswers + 1)])
+            .domain([0, d3.max([1, d3.max(data, (d) => d.totalAnswers)])])
             .range([0, width]);
         svge.append('g')
             .attr('transform', `translate(0, ${height})`)
@@ -93,7 +93,10 @@ d3.json(
 
         svgd.append('g')
             .attr('transform', `translate(0, ${height})`)
-            .call(d3.axisBottom(x));
+            .call(d3.axisBottom(x))
+            .selectAll("text")
+            .attr("transform", "translate(-10,0)rotate(-35)")
+            .style("text-anchor", "end");
 
         let y = d3.scaleLinear()
             .domain([0, 1])

--- a/AdaptiveSurveyBackend/src/main/resources/templates/fragments/layout.html
+++ b/AdaptiveSurveyBackend/src/main/resources/templates/fragments/layout.html
@@ -5,11 +5,14 @@
     <link rel="stylesheet" th:href="@{/css/style.css}"/>
 
     <link rel="stylesheet" th:href="@{/webjars/bootstrap/4.5.3/css/bootstrap.min.css}"/>
-    <link rel="stylesheet" th:href="@{/webjars/jquery/3.5.1/jquery.min.js}"/>
+    <link rel="text/javascript" th:href="@{/webjars/jquery/3.5.1/jquery.min.js}"/>
 
     <script th:fragment="paths" th:inline="javascript" type="text/javascript">
         const context = /*[[@{/}]]*/ '';
+        const token = /*[[${token}]]*/ '';
+
         console.debug('context: ' + context)
+        console.debug('token:   ' + token)
     </script>
 
     <meta charset="UTF-8">

--- a/AdaptiveSurveyBackend/src/main/resources/templates/index.html
+++ b/AdaptiveSurveyBackend/src/main/resources/templates/index.html
@@ -9,6 +9,17 @@
     <div th:replace="fragments/layout :: header"></div>
 
     <div class="jumbotron">
+        <h1>AdapQuest Demo</h1>
+        <p>
+            Add <span class="code">?show=true</span> ad the end of the url of a survey page to show the evolution of the
+            adaptive engine in real time.
+            <br/>
+            Alternatively, the recap is shown in the final page.
+        </p>
+        <p>
+            This demo is not intended to be a final product or usable in a production environment.
+        </p>
+
         <p>Adaptive Surveys available</p>
 
         <ul>

--- a/AdaptiveSurveyBackend/src/main/resources/templates/results.html
+++ b/AdaptiveSurveyBackend/src/main/resources/templates/results.html
@@ -20,17 +20,16 @@
                 <li>Start: <span th:text="${result.data}"></span></li>
                 <li>Length: <span th:text="${result.seconds}+' second(s)'"></span></li>
                 <li>Answers: <span th:text="${result.state.totalAnswers}"></span></li>
-                <li th:each="key : ${result.state.skills}">
-                    <span th:text="${key.name}"></span>:&nbsp;<span
-                        th:text="${#numbers.formatDecimal(result.state.skillDistribution.get(key.name)[1], 1, 2)}+' '"></span>
-                </li>
             </ul>
         </div>
 
-        <div id="chart-entropy"></div>
+        <div class="charts">
+            <div id="chart-entropy"></div>
+            <div id="chart-distribution"></div>
+        </div>
 
         <div>
-            Risposte:
+            Answers:
             <ul>
                 <li th:each="answer : ${answers}">
                     D: <span th:text="${answer.getQuestion().getQuestion()}"></span>

--- a/AdaptiveSurveyBackend/src/main/resources/templates/results.html
+++ b/AdaptiveSurveyBackend/src/main/resources/templates/results.html
@@ -16,11 +16,9 @@
 
     <div class="jumbotron">
         <div>
-            <ul>
-                <li>Start: <span th:text="${result.data}"></span></li>
-                <li>Length: <span th:text="${result.seconds}+' second(s)'"></span></li>
-                <li>Answers: <span th:text="${result.state.totalAnswers}"></span></li>
-            </ul>
+            <div>Start: <span th:text="${result.data}"></span></div>
+            <div>Length: <span th:text="${result.seconds}+' second(s)'"></span></div>
+            <div>Answers: <span th:text="${result.state.totalAnswers}"></span></div>
         </div>
 
         <div class="charts">

--- a/AdaptiveSurveyBackend/src/main/resources/templates/results.html
+++ b/AdaptiveSurveyBackend/src/main/resources/templates/results.html
@@ -26,6 +26,9 @@
                 </li>
             </ul>
         </div>
+
+        <div id="chart-entropy"></div>
+
         <div>
             Risposte:
             <ul>
@@ -36,6 +39,8 @@
                 </li>
             </ul>
         </div>
+        <script src="https://d3js.org/d3.v4.js"></script>
+        <script th:src="@{/js/charts.js}"></script>
     </div>
 
     <div th:replace="fragments/layout :: footer"></div>

--- a/AdaptiveSurveyBackend/src/main/resources/templates/survey.html
+++ b/AdaptiveSurveyBackend/src/main/resources/templates/survey.html
@@ -29,30 +29,23 @@
                     </li>
                 </ul>
             </div>
+            <input th:value="'▶'" type="submit"/>
 
             <div th:if="${state != null && show}">
-                <h3>State</h3>
                 <ul>
-                    <li>Created: <span th:text="${state.creationTime}"></span></li>
                     <li>Answers: <span th:text="${state.totalAnswers}"></span></li>
-                    <li th:each="key : ${state.skills}">
-                        Skill: <span th:text="${key.name}"></span>
-                        <br/>
-                        Distribution: <span th:each="d : ${state.skillDistribution.get(key.name)}"
-                                            th:text="${#numbers.formatDecimal(d, 1, 2)}+' '"></span>
-                        <br/>
-                        Entropy: <span
-                            th:text="${#numbers.formatDecimal(state.entropyDistribution.get(key.name), 1, 2)}"></span>
-                    </li>
                 </ul>
-                <div id="chart-entropy"></div>
+
+                <div class="charts">
+                    <div id="chart-entropy"></div>
+                    <div id="chart-distribution"></div>
+                </div>
 
                 <script src="https://d3js.org/d3.v4.js"></script>
                 <script th:src="@{/js/charts.js}"></script>
 
                 <div th:replace="fragments/layout :: footer"></div>
             </div>
-            <input th:value="'▶'" type="submit"/>
         </div>
     </form>
 </div>

--- a/AdaptiveSurveyBackend/src/main/resources/templates/survey.html
+++ b/AdaptiveSurveyBackend/src/main/resources/templates/survey.html
@@ -45,12 +45,16 @@
                             th:text="${#numbers.formatDecimal(state.entropyDistribution.get(key.name), 1, 2)}"></span>
                     </li>
                 </ul>
+                <div id="chart-entropy"></div>
+
+                <script src="https://d3js.org/d3.v4.js"></script>
+                <script th:src="@{/js/charts.js}"></script>
+
+                <div th:replace="fragments/layout :: footer"></div>
             </div>
             <input th:value="'▶'" type="submit"/>
         </div>
     </form>
-
-    <div th:replace="fragments/layout :: footer"></div>
 </div>
 
 </body>

--- a/AdaptiveSurveyBackend/src/main/resources/templates/survey.html
+++ b/AdaptiveSurveyBackend/src/main/resources/templates/survey.html
@@ -22,20 +22,20 @@
                 <p th:text="${question.explanation}"></p>
                 <p th:text="${question.question}"></p>
 
-                <ul>
-                    <li th:each="answer : ${question.answers}" th:with="aid = ${'a'+answer.id}">
-                        <input th:id="${aid}" th:name="answerId" th:value="${answer.id}" type="radio"/>
-                        <label th:for="${aid}" th:text="${answer.text}"></label>
-                    </li>
-                </ul>
+                <div class="answers">
+                    <div class="answer" th:each="answer : ${question.answers}" th:with="aid = ${'a'+answer.id}">
+                        <input class="radio-custom" th:id="${aid}" th:name="answerId" th:value="${answer.id}"
+                               type="radio"/>
+                        <label class="radio-custom-label" th:for="${aid}" th:text="${answer.text}"></label>
+                    </div>
+                </div>
             </div>
-            <input th:value="'▶'" type="submit"/>
+
+            <div class="submit">
+                <input th:value="'▶'" type="submit"/>
+            </div>
 
             <div th:if="${state != null && show}">
-                <ul>
-                    <li>Answers: <span th:text="${state.totalAnswers}"></span></li>
-                </ul>
-
                 <div class="charts">
                     <div id="chart-entropy"></div>
                     <div id="chart-distribution"></div>
@@ -44,10 +44,11 @@
                 <script src="https://d3js.org/d3.v4.js"></script>
                 <script th:src="@{/js/charts.js}"></script>
 
-                <div th:replace="fragments/layout :: footer"></div>
             </div>
         </div>
     </form>
+
+    <div th:replace="fragments/layout :: footer"></div>
 </div>
 
 </body>


### PR DESCRIPTION
Added charts for entropy/score and target skill probability distributions when using the `?show=true` option in a survey page and in the results page.