### PR TITLE
25 cant use springboot base url

### DIFF
--- a/AdapQuestBackend/src/main/resources/static/js/charts.js
+++ b/AdapQuestBackend/src/main/resources/static/js/charts.js
@@ -7,7 +7,7 @@ const width = 500 - margin.left - margin.right;
 const height = 400 - margin.top - margin.bottom;
 
 // following is the entropy lines chart
-d3.json('/survey/states/' + token)
+d3.json(context + 'survey/states/' + token)
     .then((data) => {
         const entropies = []
 
@@ -99,7 +99,7 @@ d3.json('/survey/states/' + token)
     });
 
 // following is the distribution bar chart
-d3.json('/survey/state/' + token)
+d3.json(context + 'survey/state/' + token)
     .then(data => {
         const distributions = []
         data.skills.forEach(s => {

--- a/AdapQuestBackend/src/main/resources/templates/assist.html
+++ b/AdapQuestBackend/src/main/resources/templates/assist.html
@@ -65,7 +65,7 @@
             <div id="chart-distribution"></div>
         </div>
 
-        <script th:src="@{~/js/charts.js}"></script>
+        <script th:src="@{/js/charts.js}"></script>
     </div>
 
     <div th:replace="fragments/layout :: footer"></div>

--- a/AdapQuestBackend/src/main/resources/templates/experiments.html
+++ b/AdapQuestBackend/src/main/resources/templates/experiments.html
@@ -21,7 +21,7 @@
             <form method="post" action="" enctype="multipart/form-data">
                 <div class="input-group mb-3">
                     <div class="">
-                        <a class="btn btn-primary" th:href="@{~/experiments/template}" role="button">
+                        <a class="btn btn-primary" th:href="@{/experiments/template}" role="button">
                             <i class="bi bi-download"></i>
                             &nbsp;
                             Template
@@ -58,13 +58,13 @@
                     <td th:text="${experiment.getName()}"></td>
                     <td th:text="${#temporals.format(experiment.getCreation(), 'yyyy-MM-dd HH:mm')}"></td>
                     <td>
-                        <a th:href="|@{~/experiments/experiment/}${experiment.getName()}|"><i
+                        <a th:href="|@{/experiments/experiment/}${experiment.getName()}|"><i
                                 class="bi bi-download"></i></a>
                     </td>
                     <td th:text="${#temporals.format(experiment.getCompletion(), 'yyyy-MM-dd HH:mm')}"></td>
                     <td>
                         <a th:if="${experiment.getCompleted()}"
-                           th:href="|@{~/experiments/result/}${experiment.getResult()}|">
+                           th:href="|@{/experiments/result/}${experiment.getResult()}|">
                             <i class="bi bi-download">
 
                             </i></a>

--- a/AdapQuestBackend/src/main/resources/templates/fragments/layout.html
+++ b/AdapQuestBackend/src/main/resources/templates/fragments/layout.html
@@ -1,15 +1,15 @@
 <!DOCTYPE html>
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
 <head th:fragment="layout">
-    <link rel="shortcut icon" th:href="@{~/img/favicon.ico}" type="image/ico"/>
-    <link rel="stylesheet" th:href="@{~/css/style.css}"/>
+    <link rel="shortcut icon" th:href="@{/img/favicon.ico}" type="image/ico"/>
+    <link rel="stylesheet" th:href="@{/css/style.css}"/>
 
-    <link rel="stylesheet" th:href="@{~/webjars/bootstrap/4.5.3/css/bootstrap.min.css}"/>
-    <link rel="stylesheet" th:href="@{~/webjars/bootstrap-icons/1.7.0/font/bootstrap-icons.css}">
-    <link rel="text/javascript" th:href="@{~/webjars/jquery/3.6.0/jquery.min.js}"/>
+    <link rel="stylesheet" th:href="@{/webjars/bootstrap/4.5.3/css/bootstrap.min.css}"/>
+    <link rel="stylesheet" th:href="@{/webjars/bootstrap-icons/1.7.0/font/bootstrap-icons.css}">
+    <link rel="text/javascript" th:href="@{/webjars/jquery/3.6.0/jquery.min.js}"/>
 
     <script th:fragment="paths" th:inline="javascript" type="text/javascript">
-        const context = /*[[@{~/}]]*/ '';
+        const context = /*[[@{/}]]*/ '';
         const token = /*[[${token}]]*/ '';
 
         console.debug('context: ' + context)
@@ -28,7 +28,7 @@
     <div th:fragment="header">
         <nav class="navbar navbar-expand-lg navbar-dark bg-primary fixed-top" th:fragment="navbar">
             <div class="container">
-                <a class="navbar-brand" href="#" th:href="@{~/}">AdapQuest</a>
+                <a class="navbar-brand" href="#" th:href="@{/}">AdapQuest</a>
                 <button aria-controls="navbarColor01" aria-expanded="false" aria-label="Toggle navigation"
                         class="navbar-toggler"
                         data-target="#navbarColor01" data-toggle="collapse" type="button">

--- a/AdapQuestBackend/src/main/resources/templates/home.html
+++ b/AdapQuestBackend/src/main/resources/templates/home.html
@@ -15,7 +15,7 @@
                 <div class="card-body">
                     <h5 class="card-title">Demo</h5>
                     <p class="card-text">Complete surveys using the adaptive engine as a final user.</p>
-                    <a th:href="@{~/demo/}" class="btn btn-primary">Go to Demo</a>
+                    <a th:href="@{/demo/}" class="btn btn-primary">Go to Demo</a>
                 </div>
             </div>
 
@@ -23,7 +23,7 @@
                 <div class="card-body">
                     <h5 class="card-title">Assistant</h5>
                     <p class="card-text">Use the adaptive engine as a guide to complete a survey.</p>
-                    <a th:href="@{~/assistant/}" class="btn btn-primary">Go to Assistant</a>
+                    <a th:href="@{/assistant/}" class="btn btn-primary">Go to Assistant</a>
                 </div>
             </div>
 
@@ -31,7 +31,7 @@
                 <div class="card-body">
                     <h5 class="card-title">Experiments</h5>
                     <p class="card-text">Use the adaptive engine to perform batch experiments.</p>
-                    <a th:href="@{~/experiments/}" class="btn btn-primary">Go to Experiments</a>
+                    <a th:href="@{/experiments/}" class="btn btn-primary">Go to Experiments</a>
                 </div>
             </div>
 

--- a/AdapQuestBackend/src/main/resources/templates/results.html
+++ b/AdapQuestBackend/src/main/resources/templates/results.html
@@ -42,7 +42,7 @@
                 </li>
             </ul>
         </div>
-        <script th:src="@{~/js/charts.js}"></script>
+        <script th:src="@{/js/charts.js}"></script>
     </div>
 
     <div th:replace="fragments/layout :: footer"></div>

--- a/AdapQuestBackend/src/main/resources/templates/survey.html
+++ b/AdapQuestBackend/src/main/resources/templates/survey.html
@@ -60,7 +60,7 @@
                     <div id="chart-distribution"></div>
                 </div>
 
-                <script th:src="@{~/js/charts.js}"></script>
+                <script th:src="@{/js/charts.js}"></script>
             </div>
         </div>
     </form>

--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ chose `Postgres 13.1` but any other SQL-based engine supported by *Hibernate* sh
 
 Refer to the [Wiki](https://github.com/IDSIA/adapquest/wiki) for more details on the `docker-compose` configuration.
 
+> **Note:** to change the context path of the application it is possible to use the environment variable `SERVER_SERVLET_CONTEXT-PATH`.
+
+
 ## Keycloak integration
 
 It is possible to use Keycloak as identity provider instead of the simple APIkey internal mechanism.


### PR DESCRIPTION
Fixed issue with Sprongboot base URL as suggested in #25 .

Basically, removed the tilde `~` sign from all url in Thymeleaf pages (i.e. from `@{~/foo/bar}` to `@{/foo/bar}`).