### PR TITLE
26 broken demo config

### DIFF
--- a/AdapQuestBackend/src/main/java/ch/idsia/adaptive/backend/services/InitializationService.java
+++ b/AdapQuestBackend/src/main/java/ch/idsia/adaptive/backend/services/InitializationService.java
@@ -178,6 +178,11 @@ public class InitializationService {
 						.setYesOnly(q.yesOnly)
 						.setMultipleSkills(q.multipleSkills)
 						.addAnswersAvailable(q.answers.stream()
+								.peek(a -> {
+									if (a.variable < 0) {
+										a.setVariable(v.get(q.name));
+									}
+								})
 								.map(a -> new QuestionAnswer()
 										.setName(a.name)
 										.setText(a.text)


### PR DESCRIPTION
It is possible to specify the whole model using JSON. In this case, the variable that connect a question to a model is generated by the software. If this variable is not set, then the model cannot figure out which question is for which variable.

The solution was to add a check for the missing variables (since we already keep track in a map of model's variables and node names), then set the variable in case of a question does not have one.