### PR TITLE
Dev QoL enhancements

### DIFF
--- a/AdapQuestBackend/src/main/java/ch/idsia/adaptive/backend/config/SecurityKeycloakConfig.java
+++ b/AdapQuestBackend/src/main/java/ch/idsia/adaptive/backend/config/SecurityKeycloakConfig.java
@@ -17,6 +17,8 @@ import org.springframework.security.core.session.SessionRegistryImpl;
 import org.springframework.security.web.authentication.session.RegisterSessionAuthenticationStrategy;
 import org.springframework.security.web.authentication.session.SessionAuthenticationStrategy;
 
+import java.util.Objects;
+
 @KeycloakConfiguration
 @AutoConfigureAfter(SecurityConfig.class)
 @ConditionalOnProperty(name = "keycloak.enabled", havingValue = "true")
@@ -24,7 +26,7 @@ class SecurityKeycloakConfig extends KeycloakWebSecurityConfigurerAdapter {
 	private static final Logger logger = LoggerFactory.getLogger(SecurityKeycloakConfig.class);
 
 	@Value("${adapquest.keycloak.role}")
-	private String role = "user";
+	private String role = "";
 
 	@Value("${adapquest.keycloak.admin}")
 	private String admin = "admin";
@@ -49,14 +51,23 @@ class SecurityKeycloakConfig extends KeycloakWebSecurityConfigurerAdapter {
 	@Override
 	protected void configure(HttpSecurity http) throws Exception {
 		super.configure(http);
-		http.authorizeRequests()
-				.antMatchers("/", "/css/**", "/webjars/**", "/img/**").permitAll()
-				.and()
-				.authorizeRequests()
-				.antMatchers("/demo**", "/survey**").hasRole(role)
-				.antMatchers("/console*").hasRole(admin)
-				.anyRequest()
-				.authenticated();
-		;
+		if (Objects.isNull(role) || role.isEmpty()) {
+			http.authorizeRequests()
+					.antMatchers("/", "/css/**", "/webjars/**", "/img/**").permitAll()
+					.and()
+					.authorizeRequests()
+					.antMatchers("/console*").hasRole(admin)
+					.anyRequest()
+					.authenticated();
+		} else {
+			http.authorizeRequests()
+					.antMatchers("/", "/css/**", "/webjars/**", "/img/**").permitAll()
+					.and()
+					.authorizeRequests()
+					.antMatchers("/demo**", "/survey**").hasRole(role)
+					.antMatchers("/console*").hasRole(admin)
+					.anyRequest()
+					.authenticated();
+		}
 	}
 }

--- a/AdapQuestBackend/src/main/java/ch/idsia/adaptive/backend/controller/HomeController.java
+++ b/AdapQuestBackend/src/main/java/ch/idsia/adaptive/backend/controller/HomeController.java
@@ -18,6 +18,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class HomeController {
 	private static final Logger logger = LoggerFactory.getLogger(HomeController.class);
 
+	@Value("${adapquest.page.title}")
+	private String pageTitle = "AdapQuest";
+
 	@Value("${adapquest.controller.assistant}")
 	private boolean assistant = true;
 	@Value("${adapquest.controller.dashboard}")
@@ -33,6 +36,7 @@ public class HomeController {
 		model.addAttribute("dashboard", dashboard);
 		model.addAttribute("demo", demo);
 		model.addAttribute("experiments", experiments);
+		model.addAttribute("pageTitle", pageTitle);
 
 		logger.debug("assistant flag={}", assistant);
 		logger.debug("dashboard flag={}", dashboard);

--- a/AdapQuestBackend/src/main/java/ch/idsia/adaptive/backend/persistence/model/Session.java
+++ b/AdapQuestBackend/src/main/java/ch/idsia/adaptive/backend/persistence/model/Session.java
@@ -50,9 +50,9 @@ public class Session {
 	private String accessCode;
 
 	/**
-	 * Group id from keaycloak (if used).
+	 * Field with data from Keycloak (if used).
 	 */
-	private String groupId;
+	private String field;
 
 	/**
 	 * When this session started. This is also used as a seed for the randomness.

--- a/AdapQuestBackend/src/main/resources/application.properties
+++ b/AdapQuestBackend/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+adapquest.page.title=AdapQuest Project
+adapquest.exit.url=
+adapquest.exit.text=
 adapquest.controller.assistant=true
 adapquest.controller.console=true
 adapquest.controller.dashboard=true
@@ -5,6 +8,7 @@ adapquest.controller.demo=true
 adapquest.controller.experiments=true
 adapquest.keycloak.role=user
 adapquest.keycloak.admin=admin
+adapquest.keycloak.field=group_id
 keycloak.enabled=false
 spring.jpa.open-in-view=false
 spring.servlet.multipart.max-file-size=10MB

--- a/AdapQuestBackend/src/main/resources/templates/fragments/layout.html
+++ b/AdapQuestBackend/src/main/resources/templates/fragments/layout.html
@@ -19,16 +19,18 @@
     <script src="https://d3js.org/d3.v6.js"></script>
 
     <meta charset="UTF-8">
-    <title th:include=":: #pageTitle">AdapQuest Project</title>
+    <title th:include=":: #pageTitle" th:text="${pageTitle}">AdapQuest Project</title>
 </head>
 <body>
+
+<div th:text="${pageTitle}"></div>
 
 <div class="container">
 
     <div th:fragment="header">
         <nav class="navbar navbar-expand-lg navbar-dark bg-primary fixed-top" th:fragment="navbar">
             <div class="container">
-                <a class="navbar-brand" href="#" th:href="@{/}">AdapQuest</a>
+                <a class="navbar-brand" href="#" th:href="@{/}" th:text="${pageTitle}">AdapQuest</a>
                 <button aria-controls="navbarColor01" aria-expanded="false" aria-label="Toggle navigation"
                         class="navbar-toggler"
                         data-target="#navbarColor01" data-toggle="collapse" type="button">

--- a/AdapQuestBackend/src/main/resources/templates/index.html
+++ b/AdapQuestBackend/src/main/resources/templates/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
 <head th:include="fragments/layout :: layout">
-    <title id="pageTitle">AdapQuest</title>
+    <title id="pageTitle" th:text="${pageTitle}">AdapQuest</title>
 </head>
 <body>
 

--- a/AdapQuestBackend/src/main/resources/templates/results.html
+++ b/AdapQuestBackend/src/main/resources/templates/results.html
@@ -15,6 +15,10 @@
     </div>
 
     <div class="jumbotron">
+        <div class="text-center" th:if="${exitButton}">
+            <a class="btn btn-primary" th:href="${exitURL}" th:text="${exitText}"></a>
+        </div>
+
         <div>
             <div>Start: <span th:text="${result.data}"></span></div>
             <div>Length: <span th:text="${result.seconds}+' second(s)'"></span></div>
@@ -42,6 +46,11 @@
                 </li>
             </ul>
         </div>
+
+        <div class="text-center" th:if="${exitButton}">
+            <a class="btn btn-primary" th:href="${exitURL}" th:text="${exitText}"></a>
+        </div>
+
         <script th:src="@{/js/charts.js}"></script>
     </div>
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,23 @@ Refer to the [Wiki](https://github.com/IDSIA/adapquest/wiki) for more details on
 
 > **Note:** to change the context path of the application it is possible to use the environment variable `SERVER_SERVLET_CONTEXT-PATH`.
 
+## Personalization
+
+It is possible to change the title of the page using the following environment variable:
+
+```
+ADAPQUEST_PAGE_TITLE: "AdapQuest"
+```
+
+If it is required to have an _exit button_, a button that can bring the survey token outside the AdapQuest platform, it is possible to use the following two environment variables.
+
+```
+ADAPQUEST_EXIT_URL: "<some valid url>"
+ADAPQUEST_EXIT_TEXT: "<the text to show>"
+```
+
+The required token will be available in the `sid` field.
+
 
 ## Keycloak integration
 
@@ -87,22 +104,30 @@ It is possible to use Keycloak as identity provider instead of the simple APIkey
 
 In order to do so, the following environment variables must be set:
 
-````
+```
 KEYCLOAK_ENABLED: "true"
 KEYCLOAK_REALM: "<realm>"
 KEYCLOAK_AUTH_SERVER_URL: "<url>"
 KEYCLOAK_RESOURCE: "<client-name>"
 KEYCLOAK_PRINCIPAL_ATTRIBUTE: "preferred_username"
-````
+```
 
 To control the roles, set the following two environment variables to the correct roles:
 
-````
+```
 ADAPQUEST_KEYCLOAK_ROLE: "user"
 ADAPQUEST_KEYCLOAK_ADMIN: "admin"
-````
+```
 
 The `user` role is who performs the survey; the `admin` role is who can add and manage surveys.
+
+If the `user` role is not filled or empty, then no checks will be made for this role and any logged user can perform surveys.
+
+If there is the need to save some field from the Keycloak user, it is possible to do so with the following environment variable:
+
+```
+ADAPQUEST_KEYCLOAK_FIELD: "<value>"
+```
 
 Both these variables can be used in a `docker-compose` file.
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -32,8 +32,15 @@ services:
       ADAPQUEST_CONTROLLER_DEMO: "true"
       ADAPQUEST_CONTROLLER_EXPERIMENTS: "false"
 
-      ADAPQUEST_KEYCLOAK_ROLE: "user"
-      ADAPQUEST_KEYCLOAK_ADMIN: "admin"
+      ADAPQUEST_PAGE_TITLE: "AdapQuest"
+
+      ADAPQUEST_EXIT_URL: "" # not used if empty
+      ADAPQUEST_EXIT_TEXT: "" # not used if empty
+
+      ADAPQUEST_KEYCLOAK_ROLE: "user" # not used if empty
+      ADAPQUEST_KEYCLOAK_ADMIN: "admin" # ignorable
+
+      ADAPQUEST_KEYCLOAK_FIELD: "group_id" # can be a username
 
       KEYCLOAK_ENABLED: "true"
       KEYCLOAK_REALM: "<realm>"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -38,9 +38,9 @@ services:
       ADAPQUEST_EXIT_TEXT: "" # not used if empty
 
       ADAPQUEST_KEYCLOAK_ROLE: "user" # not used if empty
-      ADAPQUEST_KEYCLOAK_ADMIN: "admin" # ignorable
+      ADAPQUEST_KEYCLOAK_ADMIN: "admin"
 
-      ADAPQUEST_KEYCLOAK_FIELD: "group_id" # can be a username
+      ADAPQUEST_KEYCLOAK_FIELD: "group_id"
 
       KEYCLOAK_ENABLED: "true"
       KEYCLOAK_REALM: "<realm>"


### PR DESCRIPTION
* Added `ADAPQUEST_KEYCLOAK_FIELD` variable to control which field to store in the database associated with the logged in user (previous was hardcoded to `group_id`).

* Added check for missing `ADAPQUEST_KEYCLOAK_ROLE` when Keycloak is enabled, if missing (blank) the role will not be enforced.

* Added an _exit button_ to results page

* Added a configurable options to change the title page.

* Updated `application.properties` and `docker-compose.yaml` with the new (environment) variables.