### PR TITLE
hide IDs when showing questions

### DIFF
--- a/AdapQuestBackend/src/main/resources/templates/live/results.html
+++ b/AdapQuestBackend/src/main/resources/templates/live/results.html
@@ -25,7 +25,8 @@
 
         <div>
             <ul>
-                <li th:each="question : ${questions}">
+                <li th:each="question : ${questions}"
+                    th:if="${answers.get(question).?[!questionAnswer.text.equals('no')].size() > 0}">
                     <div>
                         <span style="font-weight: bold" th:text="${question.question}"></span>
                     </div>

--- a/AdapQuestBackend/src/main/resources/templates/live/results.html
+++ b/AdapQuestBackend/src/main/resources/templates/live/results.html
@@ -27,14 +27,13 @@
             <ul>
                 <li th:each="question : ${questions}">
                     <div>
-                        <span style="font-weight: bold" th:text="${question.name}"></span>
-                        &nbsp;
                         <span style="font-weight: bold" th:text="${question.question}"></span>
                     </div>
-                    <div th:each="answer : ${answers.get(question)}"
-                         th:with="text=${answer.questionAnswer.text}">
-                        <span th:if="${!text.equals('no')}" th:text="${text}"></span>
-                    </div>
+                    <ul>
+                        <li th:each="answer : ${answers.get(question).?[!questionAnswer.text.equals('no')]}">
+                            <span th:text="${answer.questionAnswer.text}"></span>
+                        </li>
+                    </ul>
                 </li>
             </ul>
         </div>

--- a/AdapQuestBackend/src/main/resources/templates/live/survey.html
+++ b/AdapQuestBackend/src/main/resources/templates/live/survey.html
@@ -18,9 +18,7 @@
         <input th:name="questionId" th:value="${question.id}" type="hidden">
         <div class="jumbotron">
             <div>
-                <h3 th:text="${question.name}"></h3>
-                <p th:text="${question.explanation}"></p>
-                <p th:text="${question.question}"></p>
+                <p class="lead" th:text="${question.question}"></p>
 
                 <div th:class="${question.multipleChoice} ? 'answers multi' : 'answers'">
                     <div class="answer"


### PR DESCRIPTION
This pull request implements changes to meet some expectations from the consortium. The consortium feedback is that the question ID is misleading, because it seems the questionnaire is returning questions in a random order (e.g., 1 -> 3 -> 5 -> 2 -> 4), while the order should be always the same (e.g., 1 -> 2 -> 3), with different questions.
With this pull request, we hide the question ID (both when displaying questions and final results).

Please @cbonesana review the pull request, merge it, and then release a new version of the app, so that we can update it in our KITT4SME live cluster.